### PR TITLE
close #66 가로모드로 돌아갈 때 버그 수정하기

### DIFF
--- a/app/src/main/java/com/hbs/burnout/ui/chat/ChattingAdapter.kt
+++ b/app/src/main/java/com/hbs/burnout/ui/chat/ChattingAdapter.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.hbs.burnout.R
+import com.hbs.burnout.databinding.ItemLastChattingBinding
 import com.hbs.burnout.databinding.ItemMyChattingBinding
 import com.hbs.burnout.databinding.ItemYourChattingBinding
 import com.hbs.burnout.model.Script
@@ -22,17 +23,25 @@ class ChattingAdapter : ListAdapter<Script, RecyclerView.ViewHolder>(object : Di
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return if(viewType == 0){
             YourChattingViewHolder(ItemYourChattingBinding.inflate(LayoutInflater.from(parent.context), parent, false))
-        }else{
+        }else if(viewType == 1){
             MyChattingViewHolder(ItemMyChattingBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+        }else{
+            LastChattingViewHolder(ItemLastChattingBinding.inflate(LayoutInflater.from(parent.context), parent, false))
         }
     }
 
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        if(holder is YourChattingViewHolder){
-            holder.bind(position)
-        }else if(holder is MyChattingViewHolder){
-            holder.bind(position)
+        when (holder) {
+            is YourChattingViewHolder -> {
+                holder.bind(position)
+            }
+            is MyChattingViewHolder -> {
+                holder.bind(position)
+            }
+            is LastChattingViewHolder -> {
+                holder.bind(position)
+            }
         }
     }
 
@@ -40,14 +49,20 @@ class ChattingAdapter : ListAdapter<Script, RecyclerView.ViewHolder>(object : Di
         return getItem(position).user
     }
 
-    inner class YourChattingViewHolder(private val binding: ItemYourChattingBinding) : RecyclerView.ViewHolder(binding.root) {
+    private inner class LastChattingViewHolder(private val binding: ItemLastChattingBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(position: Int){
+            binding.tvChatting.text = "미션을 클리어했습니다 \uD83C\uDF89"
+        }
+    }
+
+    private inner class YourChattingViewHolder(private val binding: ItemYourChattingBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(position: Int){
             binding.ivProfile.setImageResource(R.drawable.shrimp)
             binding.tvChatting.text = getItem(position).message
         }
     }
 
-    inner class MyChattingViewHolder(private val binding: ItemMyChattingBinding) : RecyclerView.ViewHolder(binding.root){
+    private inner class MyChattingViewHolder(private val binding: ItemMyChattingBinding) : RecyclerView.ViewHolder(binding.root){
         fun bind(position: Int){
             val chatting = getItem(position).parse()
             binding.ivProfile.setImageResource(R.drawable.gamjatwigim)

--- a/app/src/main/java/com/hbs/burnout/ui/chat/ChattingFragment.kt
+++ b/app/src/main/java/com/hbs/burnout/ui/chat/ChattingFragment.kt
@@ -88,6 +88,7 @@ class ChattingFragment : BaseFragment<FragmentChattingBinding>() {
         })
 
         viewModel.completedStage.observe(viewLifecycleOwner, EventObserver {
+            addLastMessage()
             viewModel.completeStage(stageNumber) {
                 binding.root.postDelayed({
                     (activity as? ChattingActivity)?.changeNavigationGraph(stageNumber)
@@ -143,5 +144,12 @@ class ChattingFragment : BaseFragment<FragmentChattingBinding>() {
             cameraActivityResult.launch(Intent(Intent(requireContext(), CameraMissionActivity::class.java)))
         }
         dialog.showNow(parentFragmentManager, "TakePictureDialog")
+    }
+
+    private fun addLastMessage(){
+        val chattingList = chattingAdapter.currentList.toMutableList()
+        chattingList.add(Script(2,"",0,0,999))
+        chattingAdapter.submitList(chattingList)
+        binding.rvChatting.smoothScrollToPosition(chattingList.lastIndex)
     }
 }

--- a/app/src/main/java/com/hbs/burnout/ui/ext/dialog/AnswerDialog.kt
+++ b/app/src/main/java/com/hbs/burnout/ui/ext/dialog/AnswerDialog.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.hbs.burnout.R
@@ -30,6 +31,7 @@ class AnswerDialog(
         binding.viewSelection.setOnAnswerCallback{
             answerCallBack(this,it)
         }
+
         return binding.root
     }
 
@@ -38,6 +40,8 @@ class AnswerDialog(
         dialog?.let{
             val bottomSheetDialog = dialog as BottomSheetDialog
             bottomSheetDialog.behavior.isDraggable= false
+            bottomSheetDialog.behavior.state = BottomSheetBehavior.STATE_EXPANDED;
+
         }
     }
 }

--- a/app/src/main/java/com/hbs/burnout/ui/ext/dialog/AnswerDialog.kt
+++ b/app/src/main/java/com/hbs/burnout/ui/ext/dialog/AnswerDialog.kt
@@ -10,11 +10,9 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.hbs.burnout.R
 import com.hbs.burnout.databinding.DialogSelectionBinding
+import com.hbs.burnout.ui.chat.ChattingFragment
 
-class AnswerDialog(
-    private val answer: HashMap<Int, String>,
-    private val answerCallBack: (DialogFragment, Int) -> Unit
-) : BottomSheetDialogFragment() {
+class AnswerDialog : BottomSheetDialogFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -27,19 +25,21 @@ class AnswerDialog(
         savedInstanceState: Bundle?
     ): View? {
         val binding = DialogSelectionBinding.inflate(layoutInflater, container, false)
-        binding.viewSelection.setButtonAnswer(answer)
-        binding.viewSelection.setOnAnswerCallback{
-            answerCallBack(this,it)
+        val fragment  = parentFragment as ChattingFragment
+        fragment.viewModel.lastScript.value?.run {
+            binding.viewSelection.setButtonAnswer(answer)
         }
-
+        binding.viewSelection.setOnAnswerCallback {
+            fragment.answerCallback(this, it)
+        }
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        dialog?.let{
+        dialog?.let {
             val bottomSheetDialog = dialog as BottomSheetDialog
-            bottomSheetDialog.behavior.isDraggable= false
+            bottomSheetDialog.behavior.isDraggable = false
             bottomSheetDialog.behavior.state = BottomSheetBehavior.STATE_EXPANDED;
 
         }

--- a/app/src/main/java/com/hbs/burnout/utils/script/ScriptStorage.kt
+++ b/app/src/main/java/com/hbs/burnout/utils/script/ScriptStorage.kt
@@ -36,32 +36,32 @@ class ScriptStorage @Inject constructor() {
     )
 
     private val mission2 = listOf(
-        Script(0, "2번째 미션에 도착했어.", 0, 2, 0),
-        ScriptBuilder(1, "", 1, 2, 1).addAnswer(
+        Script(0, "2번째 미션에 도착했어.", 0, 2, 9),
+        ScriptBuilder(1, "", 1, 2, 10).addAnswer(
             mapOf(
                 0 to "좋아. 뭐지?",
                 1 to "..."
             )
         ).create(),
-        ScriptBuilder(0, "2번째 미션은 집 근처의 새를 찾는거야.", 0, 2, 2).create(),
-        ScriptBuilder(0, "가끔은 집 근처의 새에 관심을 갖는 것도 의미있지 않을까?", 0, 2, 3).create(),
-        ScriptBuilder(1, "", 1, 2, 4).addAnswer(
+        ScriptBuilder(0, "2번째 미션은 집 근처의 새를 찾는거야.", 0, 2, 11).create(),
+        ScriptBuilder(0, "가끔은 집 근처의 새에 관심을 갖는 것도 의미있지 않을까?", 0, 2, 12).create(),
+        ScriptBuilder(1, "", 1, 2, 13).addAnswer(
             mapOf(
                 0 to "좋아. 새를 찾으면 뭐를 하면 되지?",
                 1 to "흠~~ 귀찮은데~~"
             )
         ).create(),
-        ScriptBuilder(0, "새를 찾으면, 카메라로 사진을 찍을거야.", 2, 2, 5).addAnswer(
+        ScriptBuilder(0, "새를 찾으면, 카메라로 사진을 찍을거야.", 2, 2, 14).addAnswer(
             mapOf(
                 0 to "새를 찾으면, 카메라로 사진을 찍을거야.",
                 1 to "움직이다보면 귀찮은 것도 금방 사라질거야."
             )
         ).create(),
-        Script(0, "새를 찾으면 나에게 말을 걸어줘", 0, 2, 6),
-        Script(1, "새를 찾았어!!", 3, 2, 7),
-        Script(0, "봐봐. 해낼 줄 알았어.", 0, 2, 8),
-        Script(0, "축하해. 벌써 2번째 미션이 종료되었어.", 0, 2, 9),
-        Script(0, "너에게 또 뱃지를 줄게.", 0, 2, 10)
+        Script(0, "새를 찾으면 나에게 말을 걸어줘", 0, 2, 15),
+        Script(1, "새를 찾았어!!", 3, 2, 16),
+        Script(0, "봐봐. 해낼 줄 알았어.", 0, 2, 17),
+        Script(0, "축하해. 벌써 2번째 미션이 종료되었어.", 0, 2, 18),
+        Script(0, "너에게 또 뱃지를 줄게.", 0, 2, 19)
     )
 
     fun search(scriptNumber: Int): List<Script> {

--- a/app/src/main/res/layout/item_last_chatting.xml
+++ b/app/src/main/res/layout/item_last_chatting.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+        android:layout_height="64dp">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv_chatting"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:textColor="@android:color/tertiary_text_dark"
+            android:textSize="@dimen/material_text_body1"
+            android:gravity="center" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
### 가로모드로 돌아갈 때 버그 수정하기

- [x] 바텀 네비게이션이 제대로 나오지 않는 현상 개선하기
 문제 : 
- 가로모드로 돌릴 때, 발생하는 에러는 현재 FragmentDialog의 생성자 변수에 대한 소실함.
- Fragment를 기본적으로 만들어줄 때의 구조처럼 newInstance()를 통해서 생성을 해야함.
- 하지만, 생성자의 파라매터는 Map과 콜백이라서 어떻게 해야할지 고민
 해결방법:
- 변수인 lastScript와 callback을 뷰모델과 프레그먼트에서 갖고 있도록 로직 변경
- [x] 시나리오를 완료하고, 마지막 메시지를 보여주는 ui 추가
- [x] 시나리오를 완료하고, 완료한 스테이지 이동시 데이터가 적재되지 않는 현상 개선